### PR TITLE
Fix description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Stripe Plugin for Steampipe
 
-Use SQL to query infrastructure including servers, networks, facilities and more from Stripe.
+Use SQL to query customers, products, invoices, subscriptions and more from Stripe.
 
 - **[Get started →](https://hub.steampipe.io/plugins/turbot/stripe)**
 - Documentation: [Table definitions & examples](https://hub.steampipe.io/plugins/turbot/stripe/tables)


### PR DESCRIPTION
It looks like the README was copied from another steampipe plugin; for example this one - https://github.com/turbot/steampipe-plugin-gcp

This updates the text to be Stripe-specific and more closely match the repo description text.